### PR TITLE
Get .value for each item in the comprehension, not for the target.

### DIFF
--- a/src/main/resources/docs/description/W0110.md
+++ b/src/main/resources/docs/description/W0110.md
@@ -5,8 +5,8 @@ For example:
     my_list = [-3, -2, -1, 1, 2]
     value = 0
 
-    r1 = [i for i in my_list if i > value]
-    r2 = [i for i.value in some_list]
+    r1 = [x for x in my_list if x > value]
+    r2 = [x.value for x in some_list]
 
     r3 = filter(lambda x: x > value, my_list)
     r4 = map(lambda x: x.value, some_list)


### PR DESCRIPTION
This is a very short PR that should fix a bug in the documentation example.