### PR TITLE
Remove the parens to make the example correct

### DIFF
--- a/src/main/resources/docs/description/W0108.md
+++ b/src/main/resources/docs/description/W0108.md
@@ -6,6 +6,6 @@ For example:
     def foo():
         return 42
 
-    f = lambda: foo()  # should be f = foo()
+    f = lambda: foo()  # should be f = foo
 
       


### PR DESCRIPTION
``f = lambda: foo()`` is not equivalent with ``f = foo()`` but with ``f = foo``

(FT-826)