### PR TITLE
Classify the scripts with Python 3 instead

### DIFF
--- a/src/main/resources/docs/tests/C1001.py
+++ b/src/main/resources/docs/tests/C1001.py
@@ -7,4 +7,5 @@ class OldStyleClass():
 
 class NewStyleClass(object):
     def __init__(self):
-        return
+        # Marking the file as Python 2.
+        raise Exception, "lala"

--- a/src/main/resources/docs/tests/E0106.py
+++ b/src/main/resources/docs/tests/E0106.py
@@ -5,3 +5,5 @@ def test():
         yield letter
         ##Err: E0106
         return 1
+    # Marking this file as Python 2
+    raise Exception, "a"

--- a/src/main/resources/docs/tests/E1004.py
+++ b/src/main/resources/docs/tests/E1004.py
@@ -7,3 +7,5 @@ class AnotherOldStyleClass(OldStyleClass):
     def __init__(self):
         ##Err: E1004
         super().__init__()
+        # Marking this file as Python 2
+        raise Exception, "lala"

--- a/src/main/resources/docs/tests/W0110.py
+++ b/src/main/resources/docs/tests/W0110.py
@@ -1,5 +1,6 @@
 ##Patterns: W0110
 
+
 my_list = [-3, -2, -1, 1, 2]
 value = 0
 
@@ -10,3 +11,6 @@ r2 = [i for i.value in some_list]
 r3 = filter(lambda x: x > value, my_list)
 ##Warn: W0110
 r4 = map(lambda x: x.value, some_list)
+
+# Marking this file as Python 2
+raise Exception, "lala"

--- a/src/main/scala/codacy/pylint/Pylint.scala
+++ b/src/main/scala/codacy/pylint/Pylint.scala
@@ -128,7 +128,7 @@ object Pylint extends Tool {
   def generateClassification(files: List[String]) = {
     val scriptArgs = files.mkString("###")
     val tmp = FileHelper.createTmpFile(classifyScript, "pylint", "")
-    List("python", tmp.toAbsolutePath.toString, scriptArgs).!!
+    List("python3", tmp.toAbsolutePath.toString, scriptArgs).!!
   }
 
   private def classifyFiles(files: List[String]) = {


### PR DESCRIPTION
The problem is that some patterns are working only for Python 2 and since the files were initially classified with Python 2, this results in false positives emitted for Python 3 valid code. Now the problem is that for some files, a couple of messages won't be emitted anymore, if they don't have specific Python 2 syntax, since the difference is at the semantic level, not at the syntactic AST level. 

From my point of view, though, is that we shouldn't care too much about this, Python 3 is the future and we have only a couple of patterns which are Python 2 only.

(FT-1309)