### PR TITLE
build: bump pylint version 1.7.5 > 1.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,10 +33,8 @@ val installAll =
      |apk --no-cache add 'python3>3.6.1' &&
      |wget "https://bootstrap.pypa.io/get-pip.py" -O /dev/stdout | python &&
      |wget "https://bootstrap.pypa.io/get-pip.py" -O /dev/stdout | python3 &&
-     |python -m pip install django==1.9.2 flask==0.10.1 pylint-flask==0.1 flask-wtf==0.12 --upgrade --ignore-installed --no-cache-dir &&
-     |python3 -m pip install django==1.9.2 flask==0.10.1  pylint-flask==0.1 flask-wtf==0.12 --upgrade --ignore-installed --no-cache-dir &&
-     |python -m pip install git+https://github.com/landscapeio/pylint-django@93fd04120d0690189c35b7b2eaace23117f388c5 --upgrade --ignore-installed --no-cache-dir &&
-     |python3 -m pip install git+https://github.com/landscapeio/pylint-django@93fd04120d0690189c35b7b2eaace23117f388c5 --upgrade --ignore-installed --no-cache-dir &&
+     |python -m pip install django==1.9.2 pylint-django==0.9.0 flask==0.10.1 pylint-flask==0.1 flask-wtf==0.12 --upgrade --ignore-installed --no-cache-dir &&
+     |python3 -m pip install django==1.9.2 pylint-django==0.9.0 flask==0.10.1  pylint-flask==0.1 flask-wtf==0.12 --upgrade --ignore-installed --no-cache-dir &&
      |python -m pip install pylint-common==0.2.2 &&
      |python3 -m pip install pylint-common==0.2.2 &&
      |python -m pip install pylint-celery==0.3 &&

--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,8 @@ val installAll =
      |python3 -m pip install pylint-common==0.2.2 &&
      |python -m pip install pylint-celery==0.3 &&
      |python3 -m pip install pylint-celery==0.3 &&
-     |python -m pip install pylint==1.7.5 --upgrade --ignore-installed --no-cache-dir &&
-     |python3 -m pip install pylint==1.7.5 --upgrade --ignore-installed --no-cache-dir &&
+     |python -m pip install pylint==1.8.2 --upgrade --ignore-installed --no-cache-dir &&
+     |python3 -m pip install pylint==1.8.2 --upgrade --ignore-installed --no-cache-dir &&
      |python -m pip uninstall -y pip &&
      |python3 -m pip uninstall -y pip &&
      |apk del wget ca-certificates git &&


### PR DESCRIPTION
in order to fix `unused variable __class__` and because we have
astroid at the version `1.6.x` we must upgrade pylint