### PR TITLE
Remove duplicated occurrences from test file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,7 @@ val languageVersion = "2.11.7"
 
 scalaVersion := languageVersion
 
-resolvers ++= Seq(
-  "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
-  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/releases"
-)
+resolvers := Seq("Sonatype OSS Snapshots".at("https://oss.sonatype.org/content/repositories/releases")) ++ resolvers.value
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.3.8",
@@ -47,7 +44,7 @@ val installAll =
      |python3 -m pip uninstall -y pip &&
      |apk del wget ca-certificates git &&
      |rm -rf /tmp/* &&
-     |rm -rf /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator()," ")
+     |rm -rf /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator(), " ")
 
 mappings in Universal <++= (resourceDirectory in Compile) map { (resourceDir: File) =>
   val src = resourceDir / "docs"

--- a/src/main/resources/docs/tests/E1127.py
+++ b/src/main/resources/docs/tests/E1127.py
@@ -5,11 +5,9 @@ TESTLIST = [1, 2, 3]
 
 def function1():
     ##Err: E1127
-    ##Err: E1127
     return TESTLIST[id:id:]
 
 def function2():
-    ##Err: E1127
     ##Err: E1127
     return TESTLIST['0':'1':]
 


### PR DESCRIPTION
With the recent update of codacy-plugins-test this test will fail because now we don't return duplicated occurrences of the same pattern on the same line (with different offsets).

⚠️ ⚠️ ⚠️ ⚠️
This PR dependes on this: https://github.com/codacy/codacy-plugins-test/pull/35